### PR TITLE
SRC-1: fix launch datetime to launch pad's launch datetime

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatIncomingLocalDateTime, USER_TIMEZONE } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -124,7 +125,13 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip
+              label={`(${USER_TIMEZONE}) ${formatDateTime(launch.launch_date_local)}`}
+              placement="bottom"
+              aria-label="Local launch datetime"
+          >
+            {formatIncomingLocalDateTime(launch.launch_date_local)}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,3 +1,33 @@
+const FULL_DATE_FORMAT_OPTIONS = {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+};
+
+const FULL_DATE_FORMAT_WITH_TIMEZONE_OPTIONS = {
+  ...FULL_DATE_FORMAT_OPTIONS,
+  timeZoneName: "short",
+};
+
+const OFFSET_REGEXP = /([+-]\d{2}):(\d{2})$/;
+const MINUTES_IN_HOUR = 60;
+
+function getOffsetMinutes(hours, minutes) {
+  let sign = hours < 0 ? -1 : 1;
+  return hours * MINUTES_IN_HOUR + sign * minutes;
+}
+
+function getGMTLabel(hours, minutes) {
+  let hPrefix = hours > 0 ? '+' : '';
+  let hLabel = hours ? hPrefix + hours : '';
+  let mLabel = minutes ? ':' + minutes : '';
+
+  return `GMT${hLabel}${mLabel}`;
+}
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",
@@ -8,13 +38,38 @@ export function formatDate(timestamp) {
 }
 
 export function formatDateTime(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-    timeZoneName: "short",
-  }).format(new Date(timestamp));
+  return new Intl
+      .DateTimeFormat("en-US", FULL_DATE_FORMAT_WITH_TIMEZONE_OPTIONS)
+      .format(new Date(timestamp));
 }
+
+export function formatIncomingLocalDateTime(timestamp) {
+  let date = new Date(timestamp);
+
+  let formatSuffix = '';
+  let formatOptions = FULL_DATE_FORMAT_OPTIONS;
+
+  let offsetMatch = timestamp.match(OFFSET_REGEXP);
+
+  if (offsetMatch) {
+    let offsetHours = Number(offsetMatch[1]);
+    let offsetMinutes = Number(offsetMatch[2]);
+    formatSuffix = ` ${getGMTLabel(offsetHours, offsetMinutes)}`;
+
+    let localOffsetMinutes = date.getTimezoneOffset();
+    let incomingOffsetMinutes = getOffsetMinutes(offsetHours, offsetMinutes);
+
+    date.setMinutes(date.getMinutes() + localOffsetMinutes + incomingOffsetMinutes);
+  } else {
+    formatOptions.timeZoneName = "short";
+    formatOptions.timeZone = "UTC";
+  }
+
+  let fullDatetime = new Intl
+      .DateTimeFormat("en-US", formatOptions)
+      .format(date);
+
+  return fullDatetime + formatSuffix;
+}
+
+export const USER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
- To show launch time of launch pads we parse incoming date shift (e.g. `-05:00`) and move current `Date` object to a certain minutes count. Switching to UTC time as a fallback;
- Show user's timezone time on hover;

P.S. for method `getGMTLabel` in `format-date.js` we assuming that there is no timezone with ±00:30 shift (reference books say that) - so we can safety set hours label to empty string for zero-shifted hours.

P.P.S. `SRC` in `SRC-1` stands for `S`pace `R`ocket `C`hallenge