### PR TITLE
SRC-5: add next launch countdown timer

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 REACT_APP_SPACEX_API_URL=https://api.spacexdata.com/v3
+REACT_APP_SPACEX_API_V4_URL=https://api.spacexdata.com/v4

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-router-dom": "^6.0.0-alpha.3",
     "react-scripts": "3.4.3",
     "redux": "^4.1.0",
+    "redux-thunk": "^2.3.0",
     "swr": "^0.3.0",
     "timeago.js": "^4.0.2"
   },

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { Routes, Route } from "react-router-dom";
 import { Flex, Text } from "@chakra-ui/core";
-import { createStore } from "redux";
+import { applyMiddleware, createStore } from "redux";
 import { Provider } from "react-redux";
+import thunkMiddleware from 'redux-thunk'
 
 import Launches from "./launches";
 import Launch from "./launch";
@@ -10,10 +11,11 @@ import Home from "./home";
 import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
 import FavoritesAside from "./favorites/favorites-aside";
+import NextLaunchTimer from "./launch/next-launch-timer";
 import OpenFavoritesButton from "./buttons/open-favorites-button";
 import { appReducer } from "../redux/reducer/reducer";
 
-const store = createStore(appReducer);
+const store = createStore(appReducer, applyMiddleware(thunkMiddleware));
 
 export default function App() {
   return (
@@ -52,6 +54,8 @@ function NavBar() {
       >
         ¡SPACE·R0CKETS!
       </Text>
+
+      <NextLaunchTimer />
 
       <OpenFavoritesButton />
     </Flex>

--- a/src/components/countdown-timer.js
+++ b/src/components/countdown-timer.js
@@ -1,0 +1,70 @@
+import React from "react";
+import { Box, Text } from "@chakra-ui/core";
+
+import { ONE_DAY_MS, ONE_HOUR_MS, ONE_MINUTE_MS } from "../utils/constants";
+
+export default function CountdownTimer({ date, onFinish }) {
+  let datetime = date.getTime();
+
+  let [countdownTime, setCountdownTime] = React.useState(null);
+  let intervalRef = React.useRef(null);
+
+  let clearTimer = React.useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  let tick = React.useCallback(() => {
+    let now = Date.now();
+    let distance = datetime - now;
+
+    let days = Math.floor(distance / ONE_DAY_MS);
+    let hours = Math.floor((distance % ONE_DAY_MS) / ONE_HOUR_MS);
+    let minutes = Math.floor((distance % ONE_HOUR_MS) / ONE_MINUTE_MS);
+    let seconds = Math.floor((distance % ONE_MINUTE_MS) / 1000);
+
+    setCountdownTime({ days, hours, minutes, seconds });
+
+    if (distance <= 0) {
+      clearTimer();
+      setCountdownTime({ days: 0, hours: 0, minutes: 0, seconds: 0 });
+      onFinish && onFinish();
+    }
+  }, [datetime]);
+
+  React.useEffect(() => {
+    intervalRef.current = setInterval(tick, 1000);
+
+    return clearTimer;
+  }, [tick]); // tick is changed only when datetime is changed
+
+  if (!countdownTime) {
+    return null;
+  }
+
+  return (
+    <Box display="inline" fontSize="lg">
+      <Box display="inline">
+        {countdownTime.days}
+        <Text display="inline" fontSize="xs">d</Text>
+      </Box>
+
+      <Box display="inline">
+        &nbsp;: {countdownTime.hours}
+        <Text display="inline" fontSize="xs">h</Text>
+      </Box>
+
+      <Box display="inline">
+        &nbsp;: {countdownTime.minutes}
+        <Text display="inline" fontSize="xs">m</Text>
+      </Box>
+
+      <Box display="inline">
+        &nbsp;: {countdownTime.seconds}
+        <Text display="inline" fontSize="xs">s</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/countdown-timer.js
+++ b/src/components/countdown-timer.js
@@ -32,13 +32,13 @@ export default function CountdownTimer({ date, onFinish }) {
       setCountdownTime({ days: 0, hours: 0, minutes: 0, seconds: 0 });
       onFinish && onFinish();
     }
-  }, [datetime]);
+  }, [datetime, clearTimer, onFinish]);
 
   React.useEffect(() => {
     intervalRef.current = setInterval(tick, 1000);
 
     return clearTimer;
-  }, [tick]); // tick is changed only when datetime is changed
+  }, [tick, clearTimer]); // tick is changed only when datetime is changed & clearTimer doesn't change
 
   if (!countdownTime) {
     return null;

--- a/src/components/favorites/favorites-aside.js
+++ b/src/components/favorites/favorites-aside.js
@@ -29,7 +29,7 @@ const LAUNCH_FIELDS_FILTER_STRING = [
   'mission_name',
   'launch_date_utc',
   'rocket/rocket_name',
-  'launch_site/site_name'
+  'launch_site/site_name',
 ].join(',');
 
 const LAUNCH_PAD_FIELDS_FILTER_STRING = [
@@ -115,6 +115,7 @@ export default function FavoritesAside() {
       onClose={onClose}
       placement="right"
       size="sm"
+      preserveScrollBarGap
     >
       <DrawerOverlay/>
       <DrawerContent>

--- a/src/components/launch/next-launch-timer.js
+++ b/src/components/launch/next-launch-timer.js
@@ -10,6 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
   Text,
+  useToast,
 } from "@chakra-ui/core";
 
 import CountdownTimer from "../countdown-timer";
@@ -19,6 +20,7 @@ import { formatDateTime } from "../../utils/format-date/format-date";
 
 export default function NextLaunchTimer() {
   let dispatch = useDispatch();
+  let toast = useToast();
 
   let nextLaunch = useSelector(getNextLaunchData);
   let error = useSelector(getNextLaunchError);
@@ -28,6 +30,12 @@ export default function NextLaunchTimer() {
   }, []);
 
   let onFinishLaunchTimer = React.useCallback(() => {
+    toast({
+      title: 'Next launch just started!',
+      position: 'top',
+      isClosable: true,
+    });
+
     dispatch(fetchNextLaunchAction());
   }, [dispatch]);
 

--- a/src/components/launch/next-launch-timer.js
+++ b/src/components/launch/next-launch-timer.js
@@ -1,0 +1,89 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import {
+  Box,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverTrigger,
+  Text,
+} from "@chakra-ui/core";
+
+import CountdownTimer from "../countdown-timer";
+import { getNextLaunchData, getNextLaunchError } from "../../redux/selectors/selectors";
+import { fetchNextLaunchAction } from "../../redux/asyncActions/fetchNextLaunchAction"
+import { formatDateTime } from "../../utils/format-date/format-date";
+
+export default function NextLaunchTimer() {
+  let dispatch = useDispatch();
+
+  let nextLaunch = useSelector(getNextLaunchData);
+  let error = useSelector(getNextLaunchError);
+
+  React.useEffect(() => {
+    dispatch(fetchNextLaunchAction());
+  }, []);
+
+  let onFinishLaunchTimer = React.useCallback(() => {
+    dispatch(fetchNextLaunchAction());
+  }, [dispatch]);
+
+  if (error || !nextLaunch) {
+    return null;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <Box cursor="pointer" paddingX="4">
+          <CountdownTimer date={new Date(nextLaunch.date_utc)} onFinish={onFinishLaunchTimer} />
+        </Box>
+      </PopoverTrigger>
+
+      <PopoverContent color="black" zIndex="5" _focus={{ outline: 'none' }}>
+        <PopoverArrow />
+        <PopoverCloseButton />
+
+        <PopoverBody>
+          <Box
+            marginBottom="1"
+            fontWeight="semibold"
+            letterSpacing="wide"
+            fontSize="sm"
+            textTransform="uppercase"
+          >
+            <Text
+              display="inline"
+              fontSize="xs"
+              fontWeight="normal"
+              letterSpacing="normal"
+              textTransform="none"
+            >
+              Next launch:&nbsp;
+            </Text>
+
+            {nextLaunch.name}
+          </Box>
+
+          <Box
+            color="gray.500"
+            fontWeight="semibold"
+            letterSpacing="wide"
+            fontSize="xs"
+            textTransform="uppercase"
+            isTruncated
+          >
+            {nextLaunch.rocket.name} &bull; {nextLaunch.launchpad.name}
+          </Box>
+
+          <Box fontSize="sm">
+            {formatDateTime(nextLaunch.date_utc)}
+          </Box>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/launch/next-launch-timer.js
+++ b/src/components/launch/next-launch-timer.js
@@ -27,7 +27,8 @@ export default function NextLaunchTimer() {
 
   React.useEffect(() => {
     dispatch(fetchNextLaunchAction());
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // on mount only
 
   let onFinishLaunchTimer = React.useCallback(() => {
     toast({
@@ -37,7 +38,7 @@ export default function NextLaunchTimer() {
     });
 
     dispatch(fetchNextLaunchAction());
-  }, [dispatch]);
+  }, [dispatch, toast]);
 
   if (error || !nextLaunch) {
     return null;

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -1,6 +1,8 @@
 export const ADD_TO_FAVORITES = 'ADD_TO_FAVORITES';
 export const REMOVE_FROM_FAVORITES = 'REMOVE_FROM_FAVORITES';
 
+export const SET_NEXT_LAUNCH = 'SET_NEXT_LAUNCH';
+
 export const UI_OPEN_FAVORITES_ASIDE = 'UI_OPEN_FAVORITES_ASIDE';
 export const UI_CLOSE_FAVORITES_ASIDE = 'UI_CLOSE_FAVORITES_ASIDE';
 
@@ -24,6 +26,18 @@ export function addToFavoritesAction(payload) {
 export function removeFromFavoritesAction(payload) {
     return {
         type: REMOVE_FROM_FAVORITES,
+        payload,
+    };
+}
+
+/**
+ * Creates an action to remove element from favorites list
+ * @param {{data: Object, error: Object}} payload
+ * @returns {{payload, type: string}}
+ */
+export function setNextLaunchAction(payload) {
+    return {
+        type: SET_NEXT_LAUNCH,
         payload,
     };
 }

--- a/src/redux/asyncActions/fetchNextLaunchAction.js
+++ b/src/redux/asyncActions/fetchNextLaunchAction.js
@@ -1,0 +1,36 @@
+import { setNextLaunchAction } from "../actions";
+
+const POST_QUERY_PARAMS = {
+  query: { upcoming: true },
+  options: {
+    limit: 1,
+    select: 'date_utc name',
+    populate: [
+      { path: 'rocket', select: 'name' },
+      { path: 'launchpad', select: 'name' },
+    ],
+    sort: { flight_number: 'asc' },
+  },
+};
+
+export function fetchNextLaunchAction() {
+  return function fetchNextLaunchThunk(dispatch) {
+    let data, error;
+
+    return fetch(`${process.env.REACT_APP_SPACEX_API_V4_URL}/launches/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(POST_QUERY_PARAMS),
+    })
+      .then((response) => response.json())
+      .then((res) => {
+        data = res.docs && res.docs[0];
+      })
+      .catch((err) => {
+        error = err;
+      })
+      .then(() => {
+        dispatch(setNextLaunchAction({ data, error }));
+      });
+  };
+}

--- a/src/redux/reducer/reducer.js
+++ b/src/redux/reducer/reducer.js
@@ -1,4 +1,10 @@
-import { ADD_TO_FAVORITES, REMOVE_FROM_FAVORITES, UI_CLOSE_FAVORITES_ASIDE, UI_OPEN_FAVORITES_ASIDE } from "../actions";
+import {
+  ADD_TO_FAVORITES,
+  REMOVE_FROM_FAVORITES,
+  SET_NEXT_LAUNCH,
+  UI_CLOSE_FAVORITES_ASIDE,
+  UI_OPEN_FAVORITES_ASIDE,
+} from "../actions";
 import { getLocalStorageFavorites, setLocalStorageData } from "../../utils/storage/storage";
 import { AVAILABLE_FAVORITE_TYPES, FAVORITES_KEY } from "../../utils/constants";
 
@@ -58,6 +64,18 @@ export function appReducer(state = initialState, action) {
       return {
         ...state,
         favorites: updatedFavorites,
+      };
+    }
+
+    case SET_NEXT_LAUNCH: {
+      let { data, error } = action.payload;
+
+      return {
+        ...state,
+        nextLaunch: {
+          data,
+          error,
+        },
       };
     }
 

--- a/src/redux/reducer/reducer.spec.js
+++ b/src/redux/reducer/reducer.spec.js
@@ -1,5 +1,11 @@
 import { appReducer } from "./reducer";
-import { addToFavoritesAction, removeFromFavoritesAction, SET_NEXT_LAUNCH } from "../actions";
+import {
+  addToFavoritesAction,
+  removeFromFavoritesAction,
+  SET_NEXT_LAUNCH,
+  UI_CLOSE_FAVORITES_ASIDE,
+  UI_OPEN_FAVORITES_ASIDE
+} from "../actions";
 import { setLocalStorageData } from "../../utils/storage/storage";
 
 jest.mock('../../utils/storage/storage');
@@ -19,7 +25,7 @@ describe('reducer', () => {
         },
       };
 
-      expect(appReducer(state, { type: 'UI_CLOSE_FAVORITES_ASIDE' })).toEqual({
+      expect(appReducer(state, { type: UI_CLOSE_FAVORITES_ASIDE })).toEqual({
         ui: {
           isFavoritesAsideOpen: false,
         },
@@ -33,7 +39,7 @@ describe('reducer', () => {
         },
       };
 
-      expect(appReducer(state, { type: 'UI_OPEN_FAVORITES_ASIDE' })).toEqual({
+      expect(appReducer(state, { type: UI_OPEN_FAVORITES_ASIDE })).toEqual({
         ui: {
           isFavoritesAsideOpen: true,
         },

--- a/src/redux/reducer/reducer.spec.js
+++ b/src/redux/reducer/reducer.spec.js
@@ -1,5 +1,5 @@
 import { appReducer } from "./reducer";
-import { addToFavoritesAction, removeFromFavoritesAction } from "../actions";
+import { addToFavoritesAction, removeFromFavoritesAction, SET_NEXT_LAUNCH } from "../actions";
 import { setLocalStorageData } from "../../utils/storage/storage";
 
 jest.mock('../../utils/storage/storage');
@@ -36,6 +36,27 @@ describe('reducer', () => {
       expect(appReducer(state, { type: 'UI_OPEN_FAVORITES_ASIDE' })).toEqual({
         ui: {
           isFavoritesAsideOpen: true,
+        },
+      });
+    });
+  });
+
+  describe('next launch', () => {
+    it('should set provided data & error params', () => {
+      let state = {};
+
+      let action = {
+        type: SET_NEXT_LAUNCH,
+        payload: {
+          data: { id: 'launch_1' },
+          error: { message: 'test error' },
+        },
+      };
+
+      expect(appReducer(state, action)).toEqual({
+        nextLaunch: {
+          data: { id: 'launch_1' },
+          error: { message: 'test error' },
         },
       });
     });

--- a/src/redux/selectors/selectors.js
+++ b/src/redux/selectors/selectors.js
@@ -11,3 +11,11 @@ export function isItemFavorite(state, itemType, itemId) {
 
   return Boolean(favorites && favorites[itemType] && favorites[itemType].includes(itemId));
 }
+
+export function getNextLaunchData(state) {
+  return state.nextLaunch && state.nextLaunch.data;
+}
+
+export function getNextLaunchError(state) {
+  return state.nextLaunch && state.nextLaunch.error;
+}

--- a/src/redux/selectors/selectors.spec.js
+++ b/src/redux/selectors/selectors.spec.js
@@ -1,4 +1,10 @@
-import { getFavorites, isItemFavorite, isUIFavoritesAsideOpen } from "./selectors";
+import {
+  getFavorites,
+  getNextLaunchData,
+  getNextLaunchError,
+  isItemFavorite,
+  isUIFavoritesAsideOpen
+} from "./selectors";
 
 describe('selectors', () => {
   describe('getFavorites', () => {
@@ -20,6 +26,44 @@ describe('selectors', () => {
       let state = { ui: { isFavoritesAsideOpen: true } };
 
       expect(isUIFavoritesAsideOpen(state)).toBeTruthy();
+    });
+  });
+
+  describe('next launch', () => {
+    it('getNextLaunchData should work', () => {
+      let state = {
+        nextLaunch: {
+          data: { id: 'launch_1' },
+        },
+      };
+
+      expect(getNextLaunchData(state)).toEqual({ id: 'launch_1' });
+    });
+
+    it('getNextLaunchError should work', () => {
+      let state = {
+        nextLaunch: {
+          error: { message: 'test error' },
+        },
+      };
+
+      expect(getNextLaunchError(state)).toEqual({ message: 'test error' });
+    });
+
+    it('should work with empty object', () => {
+      let state = {
+        nextLaunch: {},
+      };
+
+      expect(getNextLaunchData(state)).toBeUndefined();
+      expect(getNextLaunchError(state)).toBeUndefined();
+    });
+
+    it('should work with empty state', () => {
+      let state = {};
+
+      expect(getNextLaunchData(state)).toBeUndefined();
+      expect(getNextLaunchError(state)).toBeUndefined();
     });
   });
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,3 +5,7 @@ export const EMPTY_FAVORITES_OBJECT = {
   launches: [],
   launchPads: [],
 };
+
+export const ONE_MINUTE_MS = 1000 * 60;
+export const ONE_HOUR_MS = 1000 * 60 * 60;
+export const ONE_DAY_MS = 1000 * 60 * 60 * 24;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9076,6 +9076,11 @@ recursive-readdir@2.2.2:
   dependencies:
     minimatch "3.0.4"
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@^4.0.0, redux@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.0.tgz#eb049679f2f523c379f1aff345c8612f294c88d4"


### PR DESCRIPTION
Countdown to the next launch is placed on header. After click on timer users can see few details about upcoming launch.
When timer has reached zero, application show notification and fetch data for the next launch.

NOTE: SpaceX API v4 is used for next-launch request (also v4 supports `/query` format to specify, which data and which params do you want to receive). More info about `query` in doc: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/queries.md